### PR TITLE
Fix for input when window is minimized

### DIFF
--- a/src/InputHandler.cpp
+++ b/src/InputHandler.cpp
@@ -90,12 +90,6 @@ bool InputHandler::Initialize(HINSTANCE hInstance, HWND hWnd, int screenWidth, i
 		return false;
 	}
 
-	result = keyboard->Acquire();
-	if (FAILED(result))
-	{
-		return false;
-	}
-
 	result = directInput->CreateDevice(GUID_SysMouse, &mouse, NULL);
 	if (FAILED(result))
 	{
@@ -114,11 +108,9 @@ bool InputHandler::Initialize(HINSTANCE hInstance, HWND hWnd, int screenWidth, i
 		return false;
 	}
 
+	// These not being aquired is a valid result and happens if the window starts minimized.
+	result = keyboard->Acquire();
 	result = mouse->Acquire();
-	if (FAILED(result))
-	{
-		return false;
-	}
 
 	return true;
 }


### PR DESCRIPTION
Fixes the issue of the program crashing if you minimize the window while it is still in startup.
The issue was due to failure of device acquisition being considered an error even though it is a valid state for the device.