### PR TITLE
Shader errors now opens a message box

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,12 +120,12 @@ int WINAPI wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE, _In_ LPWSTR, _I
 
 			if(FAILED(create_shader(device, "shaders/vertex_shader.hlsl", "VS_main", SHADER_VERTEX, &inputDesc[0], 5, &vertexShader)))
 			{
-				// Can't continue the program if the shader failes to load.
+				// Can't continue the program if the shader fails to load.
 				return -1;
 			}
 			if(FAILED(create_shader(device, "shaders/pixel_shader.hlsl", "PS_main", SHADER_PIXEL, nullptr, 0, &pixelShader)))
 			{
-				// Can't continue the program if the shader failes to load.
+				// Can't continue the program if the shader fails to load.
 				return -1;
 			}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,8 +118,16 @@ int WINAPI wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE, _In_ LPWSTR, _I
 					{ "TEX", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 48, D3D11_INPUT_PER_VERTEX_DATA, 0 },
 			};
 
-			ASSERT(create_shader(device, "shaders/vertex_shader.hlsl", "VS_main", SHADER_VERTEX, &inputDesc[0], 5, &vertexShader));
-			ASSERT(create_shader(device, "shaders/pixel_shader.hlsl", "PS_main", SHADER_PIXEL, nullptr, 0, &pixelShader));
+			if(FAILED(create_shader(device, "shaders/vertex_shader.hlsl", "VS_main", SHADER_VERTEX, &inputDesc[0], 5, &vertexShader)))
+			{
+				// Can't continue the program if the shader failes to load.
+				return -1;
+			}
+			if(FAILED(create_shader(device, "shaders/pixel_shader.hlsl", "PS_main", SHADER_PIXEL, nullptr, 0, &pixelShader)))
+			{
+				// Can't continue the program if the shader failes to load.
+				return -1;
+			}
 
 			scene = std::make_unique<OurTestScene>(
 				device,

--- a/src/shader.c
+++ b/src/shader.c
@@ -89,7 +89,10 @@ static ID3DBlob* compile_shader(SHADER_TYPE type, const char* pCode, uint32_t co
 	);
 	if (error)
 	{
-		printf((char*)error->lpVtbl->GetBufferPointer(error));
+		const char* shaderType = type == SHADER_VERTEX ? "ERROR! Vertex shader." : "ERROR! Pixel shader";
+		const char* errorMessage = error->lpVtbl->GetBufferPointer(error);
+		printf(errorMessage);
+		MessageBoxA(NULL, errorMessage, shaderType, 0);
 		error->lpVtbl->Release(error);
 		return NULL;
 	}


### PR DESCRIPTION
Any errors in a shader now shows in a message box in addition to the program console.
Since the message box blocks until it has been closed the assert on shader load has been changed to a return statement.