### PR TITLE
Check for dGPU on Optimus/AMD Dedicated Switchable Graphics laptops/systems

### DIFF
--- a/eduRend.vcxproj
+++ b/eduRend.vcxproj
@@ -96,7 +96,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxcore.lib;dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -117,7 +117,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxcore.lib;dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -135,7 +135,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxcore.lib;dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -157,7 +157,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxcore.lib;dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/eduRend.vcxproj
+++ b/eduRend.vcxproj
@@ -163,6 +163,7 @@
   <ItemGroup>
     <ClInclude Include="lib\stb_image.h" />
     <ClInclude Include="src\buffers.h" />
+    <ClInclude Include="src\dgpuforcer.h" />
     <ClInclude Include="src\objmodel.h" />
     <ClInclude Include="src\quadmodel.h" />
     <ClInclude Include="src\camera.h" />

--- a/eduRend.vcxproj
+++ b/eduRend.vcxproj
@@ -96,6 +96,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -116,6 +117,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -133,6 +135,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -154,6 +157,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/eduRend.vcxproj.filters
+++ b/eduRend.vcxproj.filters
@@ -76,6 +76,9 @@
     <ClInclude Include="lib\stb_image.h">
       <Filter>Libraries</Filter>
     </ClInclude>
+    <ClInclude Include="src\dgpuforcer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\inputhandler.cpp">

--- a/src/dgpuforcer.h
+++ b/src/dgpuforcer.h
@@ -1,0 +1,125 @@
+#include <cstdint>
+#include <iostream>
+#include <vector>
+#include <array>
+#include <dxcore.h>
+#include <dxgi1_6.h>
+#include <dxgi.h>
+#include <utility>
+
+namespace DGpuForcer
+{
+	static std::pair<HRESULT, IDXGIAdapter*> GetAdapterPtr() {
+
+		static const size_t	DescStringSize = 128;
+		// Checking present graphic adapters.
+		// adapter will fallback to staying as nullptr on error
+		std::cout << "Listing available adapters:\n";
+		size_t adapterCount = 0;
+		std::vector<bool> isHardwareList;
+		std::vector<bool> isIntegratedList;
+		std::vector<std::array<char, DescStringSize>> drvDescList;
+		std::vector<IDXCoreAdapter*> adapterList;
+		IDXCoreAdapterFactory* adapterFactory = nullptr;
+		IDXGIAdapter* adapter = nullptr;
+		IDXCoreAdapterList* D3D11Adapters = nullptr;
+		GUID attributes[]{ DXCORE_ADAPTER_ATTRIBUTE_D3D11_GRAPHICS };
+
+		HRESULT hr = DXCoreCreateAdapterFactory(&adapterFactory);
+		if (FAILED(hr)) {
+			std::cerr << "Failed to create DXCoreAdapterFactory.\n";
+			goto checkFailed;
+		}
+
+		hr = adapterFactory->CreateAdapterList(_countof(attributes),
+											   attributes,
+											   &D3D11Adapters);
+		if (FAILED(hr)) {
+			std::cerr << "Failed to create Adapter list.\n";
+			goto checkFailed;
+		}
+		adapterCount = D3D11Adapters->GetAdapterCount();
+
+
+		// query adapters and store info about them
+		for (uint32_t i = 0; i < adapterCount; ++i) {
+			IDXCoreAdapter* candidate = nullptr;
+			hr = D3D11Adapters->GetAdapter(i, &candidate);
+			if (FAILED(hr)) {
+				std::cerr << "Failed to get Adapter, index " << i << ".\n";
+				isHardwareList.push_back(false);
+				isIntegratedList.push_back(false);
+				adapterList.push_back(nullptr);
+				drvDescList.push_back({});
+				continue;
+			}
+
+			std::array<char, DescStringSize> drvDesc;
+			size_t descStringBufferSize = sizeof(drvDesc);
+
+			if (candidate->IsPropertySupported(DXCoreAdapterProperty::IsHardware) &&
+				candidate->IsPropertySupported(DXCoreAdapterProperty::IsIntegrated) &&
+				candidate->IsPropertySupported(DXCoreAdapterProperty::DriverDescription)) {
+				candidate->GetProperty(DXCoreAdapterProperty::DriverDescription, descStringBufferSize, &drvDesc);
+				drvDescList.push_back(drvDesc);
+				bool isHw = false;
+				candidate->GetProperty(DXCoreAdapterProperty::IsHardware, &isHw);
+				bool isIntegrated = false;;
+				candidate->GetProperty(DXCoreAdapterProperty::IsIntegrated, &isIntegrated);
+				isHardwareList.push_back(isHw);
+				isIntegratedList.push_back(isIntegrated);
+				adapterList.push_back(candidate);
+
+				std::cout << "\t" << i << ": " << drvDesc.data() << "\n";
+			} else {
+				isHardwareList.push_back(false);
+				isIntegratedList.push_back(false);
+				adapterList.push_back(nullptr);
+				drvDescList.push_back(drvDesc);
+				std::cout << "\t" << i << ": Invalid Device\n";
+			}
+		}
+
+		// find the first non iGPU hardware adapter
+		for (size_t i = 0; i < adapterCount; ++i) {
+			if (isHardwareList[i] && !isIntegratedList[i]) {
+
+				LUID adapterLuid;
+				size_t luidSize = sizeof(adapterLuid);
+				hr = adapterList[i]->GetProperty(DXCoreAdapterProperty::InstanceLuid, luidSize, &adapterLuid);
+				if (FAILED(hr)) {
+					std::cerr << "Failed to create Adapter list.\n"; break;
+				}
+
+				// Setup older DXGI factory and get the DXGIAdapter by LUID
+				IDXGIFactory6* oldFactory = nullptr;
+				hr = CreateDXGIFactory2(0, IID_PPV_ARGS(&oldFactory));
+				if (FAILED(hr)) {
+					std::cerr << "Failed to create DXGIFactory.\n"; break;
+				}
+
+				hr = oldFactory->EnumAdapterByLuid(adapterLuid, IID_PPV_ARGS(&adapter));
+				if (FAILED(hr)) {
+					std::cerr << "Failed to aquire DXGIAdapter from LUID.\n";
+					adapter = nullptr;
+				}
+				if (oldFactory)
+					oldFactory->Release();
+
+				if (adapter)
+					std::cout << "\nPicking Adapter " << i << ": " << drvDescList[i].data() << "\n\n";
+
+				break;
+			}
+		}
+checkFailed:
+		if (D3D11Adapters) D3D11Adapters->Release();
+		if (adapterFactory) adapterFactory->Release();
+		for (size_t i = 0; i < adapterCount; ++i) {
+			if (adapterList[i])
+				adapterList[i]->Release();
+		}
+
+		return std::make_pair(hr, adapter);
+	}
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@
 
 #define VSYNC
 #define USECONSOLE
-#define FORCE_DGPU // Force to use the dGPU on systems with multiple adapters
+//#define FORCE_DGPU // Force to use the dGPU on systems with multiple adapters
 
 #include "stdafx.h"
 #include "shader.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@
 
 #define VSYNC
 #define USECONSOLE
-#define FORCE_DGPU // Force to use the dGPU on systems with multiple adapters
+//#define FORCE_DGPU // Force to use the dGPU on systems with multiple adapters
 
 
 #include <dxcore.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,12 +15,8 @@
 
 #define VSYNC
 #define USECONSOLE
-//#define FORCE_DGPU // Force to use the dGPU on systems with multiple adapters
+#define FORCE_DGPU // Force to use the dGPU on systems with multiple adapters
 
-
-#include <dxcore.h>
-#include <dxgi1_6.h>
-#include <array>
 #include "stdafx.h"
 #include "shader.h"
 #include "Window.h"
@@ -30,7 +26,9 @@
 #include "Model.h"
 #include "Scene.h"
 
-
+#ifdef FORCE_DGPU
+#include "dgpuforcer.h"
+#endif
 
 
 //--------------------------------------------------------------------------------------
@@ -53,7 +51,6 @@ static ID3D11Debug*				debugController		= nullptr;
 
 static const int				initialWinWidth		= 1024;
 static const int				initialWinHeight	= 576;
-static const size_t				DescStringSize		= 128;
 
 static InputHandler				inputHandler;
 static Window					window;
@@ -278,117 +275,12 @@ HRESULT InitDirect3DAndSwapChain(int width, int height)
 #endif
 
 	
-	
 #ifdef FORCE_DGPU
-	
-	// Checking present graphic adapters.
-	// adapter will fallback to staying as nullptr on error
-	std::cout << "Listing available adapters:\n";
-	size_t adapterCount = 0;
-	std::vector<bool> isHardwareList;
-	std::vector<bool> isIntegratedList;
-	std::vector<std::array<char, DescStringSize>> drvDescList;
-	std::vector<IDXCoreAdapter*> adapterList;
-	IDXCoreAdapterFactory* adapterFactory = nullptr;
-	IDXGIAdapter* adapter = nullptr;
-	IDXCoreAdapterList* D3D11Adapters = nullptr;
-	GUID attributes[]{ DXCORE_ADAPTER_ATTRIBUTE_D3D11_GRAPHICS };
-
-	HRESULT hr = DXCoreCreateAdapterFactory(&adapterFactory);
-	if (FAILED(hr)) {
-		std::cerr << "Failed to create DXCoreAdapterFactory.\n";
-		goto checkFailed; }
-	
-	hr = adapterFactory->CreateAdapterList(_countof(attributes),
-										  attributes,
-										   &D3D11Adapters);
-	if (FAILED(hr)) {
-		std::cerr << "Failed to create Adapter list.\n";
-		goto checkFailed; }
-	adapterCount = D3D11Adapters->GetAdapterCount();
-
-
-	// query adapters and store info about them
-	for (uint32_t i = 0; i < adapterCount; ++i)
-	{
-		IDXCoreAdapter* candidate = nullptr;
-		hr = D3D11Adapters->GetAdapter(i, &candidate);
-		if (FAILED(hr))
-		{
-			std::cerr << "Failed to get Adapter, index " << i << ".\n";
-			isHardwareList.push_back(false);
-			isIntegratedList.push_back(false);
-			adapterList.push_back(nullptr);
-			drvDescList.push_back({});
-			continue;
-		}
-
-		std::array<char, DescStringSize> drvDesc;
-		size_t descStringBufferSize = sizeof(drvDesc);
-
-		if (candidate->IsPropertySupported(DXCoreAdapterProperty::IsHardware) &&
-			candidate->IsPropertySupported(DXCoreAdapterProperty::IsIntegrated) &&
-			candidate->IsPropertySupported(DXCoreAdapterProperty::DriverDescription))
-		{
-			candidate->GetProperty(DXCoreAdapterProperty::DriverDescription, descStringBufferSize, &drvDesc);
-			drvDescList.push_back(drvDesc);
-			bool isHw = false;
-			candidate->GetProperty( DXCoreAdapterProperty::IsHardware, &isHw);
-			bool isIntegrated = false;;
-			candidate->GetProperty(DXCoreAdapterProperty::IsIntegrated, &isIntegrated);
-			isHardwareList.push_back(isHw);
-			isIntegratedList.push_back(isIntegrated);
-			adapterList.push_back(candidate);
-
-			std::cout << "\t" << i << ": " << drvDesc.data() << "\n";
-		} else
-		{
-			isHardwareList.push_back(false);
-			isIntegratedList.push_back(false);
-			adapterList.push_back(nullptr);
-			drvDescList.push_back(drvDesc);
-			std::cout << "\t" << i << ": Invalid Device\n";
-		}	
-	}
-	
-	// find the first non iGPU hardware adapter
-	for (size_t i = 0; i < adapterCount; ++i) {
-		if (isHardwareList[i] && !isIntegratedList[i]) {
-
-			LUID adapterLuid;
-			size_t luidSize = sizeof(adapterLuid);
-			hr = adapterList[i]->GetProperty(DXCoreAdapterProperty::InstanceLuid, luidSize, &adapterLuid);
-			if (FAILED(hr)) {
-				std::cerr << "Failed to create Adapter list.\n"; break; }
-
-			// Setup older DXGI factory and get the DXGIAdapter by LUID
-			IDXGIFactory6* oldFactory = nullptr;
-			hr = CreateDXGIFactory2(0, IID_PPV_ARGS(&oldFactory));
-			if (FAILED(hr)) {
-				std::cerr << "Failed to create DXGIFactory.\n"; break; }
-
-			hr = oldFactory->EnumAdapterByLuid(adapterLuid, IID_PPV_ARGS(&adapter));
-			if (FAILED(hr)) {
-				std::cerr << "Failed to aquire DXGIAdapter from LUID.\n";
-				adapter = nullptr;
-			}
-			if (oldFactory)
-				oldFactory->Release();
-
-			if (adapter)
-				std::cout << "\nPicking Adapter " << i << ": " << drvDescList[i].data() << "\n\n";
-
-			break;
-		}
-	}
-checkFailed:
-	if (D3D11Adapters) D3D11Adapters->Release();
-	if (adapterFactory) adapterFactory->Release();
-	for (size_t i = 0; i < adapterCount; ++i)
-	{
-		if (adapterList[i])
-			adapterList[i]->Release();
-	}
+	// Trying to force a dedicated Gpu on systems
+	// with multiple graphics devices.
+	auto result = DGpuForcer::GetAdapterPtr();
+	HRESULT hr = result.first;
+	IDXGIAdapter* adapter = result.second;
 #else
 	HRESULT hr;
 	IDXGIAdapter* adapter = nullptr;

--- a/src/parseutil.h
+++ b/src/parseutil.h
@@ -104,3 +104,37 @@ static bool find_filename_from_suffixes(const std::string& str, const std::vecto
 }
 
 #endif /* parseutil_h */
+
+/**
+ * @brief Checks if a substring is contained in a wide string (more than 8 bits per character).
+ * @brief Case insensitive.
+ * @param[in] source - The wstring to search.
+ * @param[in] substring - The substring (as regular c-string) to check for.
+ * @return True if a substring was found, False if no occurence was found.
+*/
+static bool containsSubstr_w(const std::wstring& source, const char* substring)
+{
+    wchar_t wideSubstring[128] = { 0 };
+    size_t convertedLength = 0;
+
+    auto inputLen = strlen(substring);
+
+    errno_t err = mbstowcs_s(&convertedLength, wideSubstring, 128, substring, inputLen);
+    if (err != 0)
+    {
+        // Error, check input 
+        return false;
+    }
+
+    for (size_t i = 0; i < 128; ++i)
+        wideSubstring[i] = towupper(wideSubstring[i]);
+
+    wchar_t src[128];
+    source.copy(src, source.length(), 0);
+
+    for (int i = 0; i < source.length(); i++)
+        src[i] = towupper(source[i]);
+
+    const wchar_t* result = std::wcsstr(src, wideSubstring);
+    return result != nullptr;
+}

--- a/src/parseutil.h
+++ b/src/parseutil.h
@@ -104,37 +104,3 @@ static bool find_filename_from_suffixes(const std::string& str, const std::vecto
 }
 
 #endif /* parseutil_h */
-
-/**
- * @brief Checks if a substring is contained in a wide string (more than 8 bits per character).
- * @brief Case insensitive.
- * @param[in] source - The wstring to search.
- * @param[in] substring - The substring (as regular c-string) to check for.
- * @return True if a substring was found, False if no occurence was found.
-*/
-static bool containsSubstr_w(const std::wstring& source, const char* substring)
-{
-    wchar_t wideSubstring[128] = { 0 };
-    size_t convertedLength = 0;
-
-    auto inputLen = strlen(substring);
-
-    errno_t err = mbstowcs_s(&convertedLength, wideSubstring, 128, substring, inputLen);
-    if (err != 0)
-    {
-        // Error, check input 
-        return false;
-    }
-
-    for (size_t i = 0; i < 128; ++i)
-        wideSubstring[i] = towupper(wideSubstring[i]);
-
-    wchar_t src[128];
-    source.copy(src, source.length(), 0);
-
-    for (int i = 0; i < source.length(); i++)
-        src[i] = towupper(source[i]);
-
-    const wchar_t* result = std::wcsstr(src, wideSubstring);
-    return result != nullptr;
-}


### PR DESCRIPTION
Since eduRend is creating the dx11 device passing nullptr as adapter, it will default to either adapter index 0 or maybe on some system to the 'preferred' adapter, which has to be set manually for the executable if one want to use dGPU.

Here is a hack with provided macro enable/disable to let eduRend still chose a dedicated graphics card on laptops that have them but where the default and/or adapter is the Intel iGPU. This modification provides a way to chose the behavior of choice of graphics adapter to use. This would have substantial performance benefits for some users.

Unfortunately another dependency needs to be added (DXGI) to get the interface factory but it should not cause any issues. Famous last words...

Picking Intel iGPU by checking for 'UHD' in description might not be the pretties of solutions but as of writing, as good as all lower tier iGPU's from Intel have this in their device descriptions, so currently it is a valid way of checking for it. That might change in the future, but so will the power of the iGPU's, as it might not be of any concern down the road.

UPDATE:
Latest commit does not query by vendor and/or device description strings but rather whether adapter flag 'IsIntegrated' is set and in the case it is, skip it in favor of next Hardware non-integrated device.